### PR TITLE
Validate remote HTTP specs and make headers null-safe in HttpStep

### DIFF
--- a/docs/code-review-notes.md
+++ b/docs/code-review-notes.md
@@ -1,0 +1,9 @@
+# Code Review Notes (Codex CLI)
+
+## Implemented improvements
+- Added guardrails for remote HTTP specs to validate required fields (`endpoint`, `toJson`, `fromJson`) and tolerate null headers in `HttpStep`.
+
+## Follow-up suggestions
+- Consider adding exponential backoff or jitter for remote retries to avoid thundering-herd behavior on transient failures.
+- Document the expected format of `toJson` for GET requests (query string vs JSON body) to prevent misuse.
+- Add tests to cover invalid `RemoteSpec` configurations (missing endpoint or serializers) in `pipeline-remote`.


### PR DESCRIPTION
### Motivation
- Ensure remote HTTP steps fail fast when required spec fields are missing to avoid obscure runtime errors.
- Make header handling robust when `headers` may be `null` to prevent NPEs during request building.
- Provide a brief developer-facing note about the change and follow-up suggestions under `docs`.

### Description
- Added `validateSpec` helpers for both `RemoteSpec` and `RemoteSpecTyped` that check `endpoint` is non-blank and require `toJson`/`fromJson` serializers to be non-null, and invoked them from `invoke` and `invokeTyped` respectively.
- Made header handling null-safe by using `Map<String,String> headers = spec.headers == null ? Map.of() : spec.headers` before iterating and adding headers.
- Added `docs/code-review-notes.md` documenting the implemented improvements and follow-up suggestions.
- Changes applied in `src/Java/pipeline-remote/src/main/java/com/pipeline/remote/http/HttpStep.java` and the new docs file `docs/code-review-notes.md`.

### Testing
- No automated tests were run for these changes.
- No CI/job results are available in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696500872b88832396f882233e2e04bf)